### PR TITLE
vidmodeproc.h removed from SDK

### DIFF
--- a/src/sis_driver.c
+++ b/src/sis_driver.c
@@ -105,8 +105,6 @@
 #include "sis_regs.h"
 #include "sis_dac.h"
 
-#include <vidmodeproc.h>
-
 #include "sis_driver.h"
 
 #include <X11/extensions/xf86dgaproto.h>


### PR DESCRIPTION
The file vidmodeproc.h has been removed from the SDK, see https://lists.x.org/archives/xorg-devel/2015-June/046574.html.

It isn't apparently used.

This makes the driver compile for me at OpenSUSE Tumbleweed 20161111.

Maybe you want to surround this by some additional definitions.